### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/publish_gha_timer.yml
+++ b/.github/workflows/publish_gha_timer.yml
@@ -20,11 +20,11 @@ jobs:
       - name: git config --global remote.origin.followRemoteHEAD never
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: rickstaa/action-contains-tag@v1
+      - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1.2.10
         id: contains_tag
         with:
           reference: "main"
@@ -46,16 +46,16 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
 
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: ${{ env.POETRY_VERSION }}
           virtualenvs-in-project: true
@@ -69,7 +69,7 @@ jobs:
       - name: Build package
         run: poetry build --format=sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: gha_timer-sdist
           path: dist/*.tar.gz
@@ -81,13 +81,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: packages
           pattern: 'gha_timer-*'
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: packages/
           skip-existing: true
@@ -100,13 +100,13 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         id: git-cliff
         with:
           config: pyproject.toml
@@ -123,17 +123,17 @@ jobs:
     needs: make-changelog
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Download the sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           name: ${{ github.ref_name }}
           body: ${{ needs.make-changelog.outputs.release_body }}

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         PYTHON_VERSION: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python ${{ matrix.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
 
@@ -28,12 +28,12 @@ jobs:
         run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
 
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: ${{ env.POETRY_VERSION }}
 
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: .venv
@@ -56,7 +56,7 @@ jobs:
       matrix:
         PYTHON_VERSION: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install the action
         uses: ./
@@ -83,10 +83,10 @@ jobs:
     name: Test the docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: npm ci
       - run: npm run build
       - run: npm run format-check

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.13
 
@@ -22,7 +22,7 @@ jobs:
         run: pip wheel --no-deps -w /tmp/wheelhouse .
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: gha_timer-wheel
           path: /tmp/wheelhouse/gha_timer*.whl

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: Set up Python ${{ matrix.PYTHON_VERSION }}
       id: python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.12"
         update-environment: false


### PR DESCRIPTION
## Summary
- Pin every third-party action in the composite action (`action.yml`) and in each workflow (`publish_gha_timer.yml`, `python_package.yml`, `wheels.yml`) to a full-length commit SHA, with a trailing comment noting the version.
- No behavioral changes — same versions, just pinned by SHA.

## Motivation
Consumer repositories that enforce \"all actions must be pinned to a full-length commit SHA\" (e.g. `fulcrumgenomics/fetch-through-merge-base`) already pin this composite action by SHA, but the composite still resolves `actions/setup-python@v5` at runtime and the org policy rejects the whole workflow. Pinning through the transitive chain removes that failure mode.

A new release (suggest `v1.1.1`) should be cut after merge so downstream consumers can bump their SHA.

## Test plan
- [ ] `python_package.yml` (Code checks) passes on this PR — exercises the composite action via `uses: ./`, covering the `actions/setup-python` pin
- [ ] `wheels.yml` passes on this PR
- [ ] Confirm the log shows `Download action repository 'actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065'` rather than `@v5`