### PR TITLE
chore(release): bump to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v1.1.1] (2026-04-20)
+
+CI:
+
+* Pin GitHub Actions to full-length commit SHAs (#12)
+
+[v1.1.1]: https://github.com/fulcrumgenomics/gha-timer/releases/tag/v1.1.1
+
 ## [v1.1.0] (2025-03-22)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gha-timer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gha-timer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.13.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-timer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "fetch through merge base",
   "scripts": {
     "build": "tsc && node lib/generate-docs.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "gha_timer"
-version         = "1.1.0"
+version         = "1.1.1"
 description     = "Time and group logs for GitHub actions"
 readme          = "README.md"
 authors         = [{ name="Nils Homer", email="nils@fulcrumgenomics.com" }]


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml`, `package.json`, and `package-lock.json` to `1.1.1`.
- Add `v1.1.1` CHANGELOG entry noting the CI pin from #12.

Patch release — no behavior change. Cut so downstream consumers (notably `fulcrumgenomics/fetch-through-merge-base`) can pin to a `gha-timer` SHA where every transitive action is SHA-pinned.

## Test plan
- [ ] CI green on this PR (wheels + code checks exercise the pinned composite)
- [ ] After merge, tag `v1.1.1` on `main` to trigger `publish_gha_timer.yml`