### PR TITLE
fix(ci): configure git identity before annotating v<major> tag

### DIFF
--- a/.github/workflows/publish_gha_timer.yml
+++ b/.github/workflows/publish_gha_timer.yml
@@ -143,6 +143,10 @@ jobs:
       - name: Update the latest tag
         shell: bash
         run: |
+          # `git tag -a` records a tagger identity; actions/checkout no longer
+          # configures one on the runner, so set it explicitly here.
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
           latest_tag=$(echo "${{ github.ref_name }}" | cut -c -2)
           git tag -d "${latest_tag}" || echo ""
           git tag -a -m "Release version ${{ github.ref_name }}" "${latest_tag}"


### PR DESCRIPTION
## Summary
- Set `github-actions[bot]` identity at the top of the `Update the latest tag` step so `git tag -a` can record a tagger.

## Why
`actions/checkout` does not configure `user.email` / `user.name` on the runner, so `git tag -a` fails with `empty ident name`. The step has been silently broken at least since the v1.1.1 release:

- Failing run: https://github.com/fulcrumgenomics/gha-timer/actions/runs/24699711481/job/72240282003
- Symptom: the moving `v1` tag still points at `d0db3966...` (v1.1.0-era) instead of `d0d886fa...` (v1.1.1).

The release itself (PyPI + GitHub release) was created successfully earlier in the same job — only this one step failed.

## Note
This PR only fixes **future** releases. The current stale `v1` tag still needs to be updated manually (or I can refresh it outside this PR).

## Test plan
- [ ] Next tag push (`v1.1.x` or later) refreshes `v1` successfully
- [ ] Verify `git show v1` points at the latest release commit after the next run