### PR TITLE
fix(ci): derive moving v<major> tag via parameter expansion

### DIFF
--- a/.github/workflows/publish_gha_timer.yml
+++ b/.github/workflows/publish_gha_timer.yml
@@ -147,7 +147,9 @@ jobs:
           # configures one on the runner, so set it explicitly here.
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          latest_tag=$(echo "${{ github.ref_name }}" | cut -c -2)
+          # Strip everything from the first dot onward so double-digit majors
+          # (e.g. v10.0.0 → v10) still produce the correct moving tag.
+          latest_tag="${GITHUB_REF_NAME%%.*}"
           git tag -d "${latest_tag}" || echo ""
           git tag -a -m "Release version ${{ github.ref_name }}" "${latest_tag}"
           git push origin ":refs/tags/${latest_tag}" || echo ""


### PR DESCRIPTION
## Summary
- Replace `cut -c -2` with `${GITHUB_REF_NAME%%.*}` when computing the major-version moving tag in the `Update the latest tag` step.

## Why
`cut -c -2` takes the first two characters of the tag name, which only works for single-digit majors. `v10.0.0` would be truncated to `v1` and the step would force-update the `v1` moving tag to a v10 commit — silently breaking every consumer of `gha-timer@v1`.

Parameter expansion `${GITHUB_REF_NAME%%.*}` strips everything from the first `.` onward, so:
- `v1.1.1` → `v1` ✓ (unchanged behavior)
- `v10.0.0` → `v10` ✓ (fixed)
- `v2.0.0-rc1` → `v2` ✓ (unchanged, since `-` comes after `.` wouldn't apply; the split is on the first dot)

No practical urgency — we're far from v10 — but trivial and safer than leaving the footgun in.

## Test plan
- [ ] Sanity-check in bash: `GITHUB_REF_NAME=v10.0.0 bash -c 'echo "${GITHUB_REF_NAME%%.*}"'` prints `v10`
- [ ] Next release refreshes the correct `v<major>` tag